### PR TITLE
Fix additional space after append in imx-image-full.bbappend

### DIFF
--- a/recipes-fsl/images/imx-image-full.bbappend
+++ b/recipes-fsl/images/imx-image-full.bbappend
@@ -1,7 +1,7 @@
-ROOTFS_POSTPROCESS_COMMAND:append:mx93-nxp-bsp = "install_demo_93; "
-ROOTFS_POSTPROCESS_COMMAND:append:mx8-nxp-bsp = "install_demo; "
-ROOTFS_POSTPROCESS_COMMAND:append:mx95-nxp-bsp = "install_demo; "
-ROOTFS_POSTPROCESS_COMMAND:append:mx7ulp-nxp-bsp = "install_demo; "
+ROOTFS_POSTPROCESS_COMMAND:append:mx93-nxp-bsp = " install_demo_93; "
+ROOTFS_POSTPROCESS_COMMAND:append:mx8-nxp-bsp = " install_demo; "
+ROOTFS_POSTPROCESS_COMMAND:append:mx95-nxp-bsp = " install_demo; "
+ROOTFS_POSTPROCESS_COMMAND:append:mx7ulp-nxp-bsp = " install_demo; "
 
 install_demo() {
     if ! grep -q "icon=/opt/gopoint-apps/icon/icon_demo_launcher.png" ${IMAGE_ROOTFS}${sysconfdir}/xdg/weston/weston.ini


### PR DESCRIPTION
Fix a very old error from d1adfabd, where there should be an additional space for append statement.